### PR TITLE
Palindrome for odd case and setup testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # lvl-up
 
-# Next Larger Palindrome
+# Setup
+1. Ensure you have the `elixir 1.10` or greater and `erlang 23.0` installed on your system
+2. Go into a problem set folder
+3. Ensure there is a `mix.exs` file and then run the following commands:
+    1. `mix deps.get` - This will fetch an projec dependencies
+    2. `mix test` - This will run the test.
+
+# Problem Set
+## Next Larger Palindrome
 Next Larger Palindrome goes like this:
 You are given a number, and you need to find the next larger palindrome.
 
@@ -11,7 +19,7 @@ You are given a number, and you need to find the next larger palindrome.
 9999 => 10001
 ```
 
-# Does a Continuation Exist?
+## Does a Continuation Exist?
 We are given a 2d matrix, for example
 
 ```

--- a/palindrome/lib/palindrome.ex
+++ b/palindrome/lib/palindrome.ex
@@ -1,14 +1,15 @@
 defmodule Palindrome do
   @moduledoc false
 
-  # TODO test for valid false input
   def get_palindrome(input) when is_integer(input) do
     input
     |> Integer.to_string()
-    |> get_palindrome()
+    |> process_input()
   end
 
-  def get_palindrome(input) when is_binary(input) do
+  def get_palindrome(_), do: {:error, "Invalid input, please pass an integer"}
+
+  def process_input(input) do
     input
     |> IO.inspect(label: "RESI")
     |> String.length()
@@ -28,28 +29,43 @@ defmodule Palindrome do
 
   def compute(input, :even) do
     input
-    |> reverse()
+    |> reverse(:even)
     |> check(input)
     |> case do
-      {true, new} -> to_integer(new)
+      {true, new} -> {:ok, to_integer(new)}
       {false, new} -> increment(new, :even)
     end
   end
 
-  def reverse(input) do
+  def compute(input, :odd) do
+    input
+    |> reverse(:odd)
+    |> check(input)
+    |> case do
+      {true, new} -> {:ok, to_integer(new)}
+      {false, new} -> increment(new, :odd)
+    end
+  end
+
+  def reverse(input, :even) do
     first_half = input |> Enum.slice(0, div(length(input), 2))
     first_half ++ Enum.reverse(first_half)
+  end
+
+  def reverse(input, :odd) do
+    first_half = input |> Enum.slice(0, div(length(input), 2))
+    middle = input |> Enum.at(div(length(input), 2))
+    first_half ++ [middle] ++ Enum.reverse(first_half)
   end
 
   def check(new, old) do
     new_int = new |> to_integer()
     old_int = old |> to_integer()
-    is_palindrome = new |> List.to_string() |> String.reverse() |> String.equivalent?(new)
+    is_palindrome = new |> List.to_string() |> is_equal()
     result = new_int > old_int && is_palindrome
     {result, new}
   end
 
-  # TODO very 99 is an edge to test
   def increment(input, :even) do
     increment_by = input |> length() |> div(2)
     input_int = input |> to_integer()
@@ -57,12 +73,28 @@ defmodule Palindrome do
     (input_int + :math.pow(10, increment_by))
     |> trunc()
     |> Integer.to_string()
-    |> get_palindrome()
+    |> process_input()
+  end
+
+  def increment(input, :odd) do
+    increment_by = input |> length() |> div(2) |> Kernel.+(1)
+    input_int = input |> to_integer()
+
+    (input_int + :math.pow(10, increment_by))
+    |> trunc()
+    |> Integer.to_string()
+    |> process_input()
   end
 
   defp to_integer(input) when is_list(input) do
     input
     |> List.to_string()
     |> String.to_integer()
+  end
+
+  defp is_equal(input) do
+    input
+    |> String.reverse()
+    |> String.equivalent?(input)
   end
 end

--- a/palindrome/test/palindrome_test.exs
+++ b/palindrome/test/palindrome_test.exs
@@ -1,8 +1,24 @@
 defmodule PalindromeTest do
   use ExUnit.Case
-  doctest Palindrome
+  alias Palindrome, as: PL
 
-  test "greets the world" do
-    assert Palindrome.hello() == :world
+  test "Test valid input" do
+    assert {:ok, 1111} = PL.get_palindrome(1101)
+    assert {:ok, 9999} = PL.get_palindrome(9989)
+    assert {:ok, 12021} = PL.get_palindrome(11011)
+    assert {:ok, 1023201} = PL.get_palindrome(1013555)
+  end
+
+  test "Test invalid input" do
+    assert {:error, _} = PL.get_palindrome("11dafs")
+  end
+
+  test "even case" do
+    assert {:ok, 111} = PL.get_palindrome(99)
+    assert {:ok, 10001} = PL.get_palindrome(9999)
+  end
+
+  test "odd case" do
+
   end
 end


### PR DESCRIPTION
## Summary
* The previous commit only solved for even number input. Odd number input was not solved for.
* No testing was setup

## Purposed changes
* Odd number input resolves to the next largest palindrome
* Setup test for simple and edge cases.

## How to test
* Run `cd ./palindrome && mix test`